### PR TITLE
Rename to music-theory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/battermann/Tonal.svg?branch=develop)](https://travis-ci.org/battermann/Tonal)
 
-# elm-music-theory
+# music-theory
 
 Principled library for working with pitch classes and intervals.
 


### PR DESCRIPTION
Let's rename to music-theory because having elm in the name twice is too redundant.

Or maybe even just `theory`? But I prefer `music-theory` because that's what it is.