### PR TITLE
[WIP] Repeated accidentals

### DIFF
--- a/src/MusicTheory/Notation.elm
+++ b/src/MusicTheory/Notation.elm
@@ -19,6 +19,7 @@ module MusicTheory.Notation exposing
     , chord
     , chordNote
     , doubleLine
+    , fromStaffs
     , fromVoice
     , length
     , line
@@ -34,6 +35,7 @@ module MusicTheory.Notation exposing
     , voiceDuration
     , voiceElementDuration
     , voiceMap
+    , withKey
     )
 
 import Libs.Ratio as Ratio exposing (Rational)
@@ -209,15 +211,31 @@ bass =
     Bass
 
 
-fromVoice : Voice a -> Notation a
-fromVoice voice =
+fromVoice : Clef -> Voice a -> Notation a
+fromVoice clef voice =
     { title = Nothing
     , composer = Nothing
     , key = Key.cMajor
     , timeSignature = TimeSignature.four TimeSignature.quarters
     , tempo = Nothing
-    , staffs = [ staff treble [ voice ] ]
+    , staffs = [ staff clef [ voice ] ]
     }
+
+
+fromStaffs : List (Staff a) -> Notation a
+fromStaffs staffs =
+    { title = Nothing
+    , composer = Nothing
+    , key = Key.major (PitchClass.pitchClass C Pitch.natural)
+    , timeSignature = TimeSignature.timeSignature TimeSignature.Four TimeSignature.Quarter
+    , tempo = Nothing
+    , staffs = staffs
+    }
+
+
+withKey : Key -> Notation a -> Notation a
+withKey key notation =
+    { notation | key = key }
 
 
 

--- a/src/MusicTheory/Notation.elm
+++ b/src/MusicTheory/Notation.elm
@@ -226,8 +226,8 @@ fromStaffs : List (Staff a) -> Notation a
 fromStaffs staffs =
     { title = Nothing
     , composer = Nothing
-    , key = Key.major (PitchClass.pitchClass C Pitch.natural)
-    , timeSignature = TimeSignature.timeSignature TimeSignature.Four TimeSignature.Quarter
+    , key = Key.cMajor
+    , timeSignature = TimeSignature.four TimeSignature.quarters
     , tempo = Nothing
     , staffs = staffs
     }

--- a/tests/Notation/AbcTests.elm
+++ b/tests/Notation/AbcTests.elm
@@ -180,7 +180,7 @@ all =
                         , note [] (cNatural five) sixteenthNote
                         ]
                     ]
-                    |> fromVoice
+                    |> fromVoice treble
                     |> Abc.fromNotation 4
                     |> Expect.equal expected
         , test "multiple staffs to ABC notation" <|
@@ -199,6 +199,51 @@ all =
                         "M: 4/4\n%%score (0 1) (2) (3 4)\nV: 0 clef=treble\nV: 1 clef=treble\nV: 2 clef=bass\nV: 3 clef=treble\nV: 4 clef=treble\nK: C\n[V:0]=C8/1 | =C8/1 | =C8/1 | =C8/1 |\n[V:1]=E8/1 | =E8/1 | =E8/1 | =E8/1 |\n[V:2]=A,,8/1 | =A,,8/1 | =A,,8/1 | =A,,8/1 |\n[V:3]=B8/1 | =B8/1 | =B8/1 | =B8/1 |\n[V:4]=d8/1 | =d8/1 | =d8/1 | =d8/1 |\n[V:0] =C8/1 | =C8/1 | =C8/1 | =C8/1 |\n[V:1] =E8/1 | =E8/1 | =E8/1 | =E8/1 |\n[V:2] =A,,8/1 | =A,,8/1 | =A,,8/1 | =A,,8/1 |\n[V:3] =B8/1 | =B8/1 | =B8/1 | =B8/1 |\n[V:4] =d8/1 | =d8/1 | =d8/1 | =d8/1 |\n[V:0] =C8/1 | =C8/1 | \n[V:1] =E8/1 | =E8/1 | \n[V:2] =A,,8/1 | =A,,8/1 | \n[V:3] =B8/1 | =B8/1 | \n[V:4] =d8/1 | =d8/1 | "
                 in
                 multipleLines
+                    |> Abc.fromNotation 4
+                    |> Expect.equal expected
+        , test "repeated accidentals" <|
+            \_ ->
+                let
+                    voice1 =
+                        [ bar []
+                            [ line
+                                [ note [] (cSharp five) quarterNote
+                                , note [] (dNatural five) quarterNote
+                                , rest [] quarterNote
+                                , note [] (eNatural five) quarterNote
+                                ]
+                            ]
+                        , bar [] [ rest [] wholeNote ]
+                        ]
+                            |> line
+
+                    voice2 =
+                        [ bar []
+                            [ line
+                                [ rest [] eighthNote
+                                , note [] (cNatural five) quarterNote
+                                , note [] (dNatural five) eighthNote
+                                , rest [] eighthNote
+                                , note [] (eFlat five) (dotted quarterNote)
+                                ]
+                            ]
+                        , bar []
+                            [ note [] (fSharp three) quarterNote
+                            , note [] (fNatural three) quarterNote
+                            , note [] (fNatural three) quarterNote
+                            , note [] (fSharp three) quarterNote
+                            ]
+                        ]
+                            |> line
+
+                    music =
+                        fromStaffs [ { clef = treble, voices = [ voice1, voice2 ] } ]
+                            |> withKey Key.gMajor
+
+                    expected =
+                        "M: 4/4\n%%score (0 1)\nV: 0 clef=treble\nV: 1 clef=treble\nK: G\n[V:0]^c2/1 d2/1 z2/1 =e2/1 | z8 |\n[V:1]z1/1 =c2/1 d1/1 z1/1 _e3/1 | F2 =F2 F2 ^F2 |"
+                in
+                music
                     |> Abc.fromNotation 4
                     |> Expect.equal expected
         ]


### PR DESCRIPTION
I only added a test that shows what is to be implemented.

The problem is not trivial at all and I currently don't have a strategy for an elegant solution.

What makes is difficult is that a staff can contain multiple voices, so it is not possible/easy to thread through a state while rendering each voice. Because the current state can affect notes from previous voices that have already been rendered.

Here is an example, which is the desired result:

<img width="794" alt="screenshot 2018-12-20 at 22 16 15" src="https://user-images.githubusercontent.com/3968185/50311290-f1d61e80-04a4-11e9-9610-f122b10f3832.png">

- The C# from the first voice influences the C from the second voice (the second C has to have a natural sign to cancel the previous sharp)
- In the first voice there is a E natural that also has to be canceled because the second voice has a Eb that comes before it
- In the second bar you can see that the key signature has to be taken into account (just to not forget that)

Currently the result would be this:

<img width="856" alt="screenshot 2018-12-20 at 22 35 11" src="https://user-images.githubusercontent.com/3968185/50312112-8fcae880-04a7-11e9-9865-ceabd18f24b3.png">


Here are the ABC codes:

Expected result:

```
M: 4/4
%%score (0 1)
V: 0 clef=treble
V: 1 clef=treble
K: G
[V:0]^c2/1 d2/1 z2/1 =e2/1 | z8 |
[V:1]z1/1 =c2/1 d1/1 z1/1 _e3/1 | F2 =F2 F2 ^F2 |
```

Actual result:

```
M: 4/4
%%score (0 1)
V: 0 clef=treble
V: 1 clef=treble
K: C
[V:0]^c2/1 =d2/1 z2/1 =e2/1 | z8/1 | 
[V:1]z1/1 =c2/1 =d1/1 z1/1 _e3/1 | ^F2/1 =F2/1 =F2/1 ^F2/1 | 
```

You can try it in this [ABC editor](https://abcjs.net/abcjs-editor.html).

It is also the question if this should be done during the ABC rendering. Or does it make more sense to have a processing step before that, where notes are assigned with an additional attribute that indicates wether the accidental is shown or not:

```
prettifyAccidentals : Notation a -> Notation a
```

The last resort would be to constrain a staff to one voice???

Or to go for a completely different `Notation` model.

Depends on #46 so this is set as the target branch ATM to have a nicer diff.